### PR TITLE
Replace turbolinks with turbo

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
         "php": "^8.0|^8.1",
-        "rapidez/core": "~0.54"
+        "rapidez/core": "~0.77"
     },
     "config": {
         "sort-packages": true

--- a/resources/js/paynl.js
+++ b/resources/js/paynl.js
@@ -1,4 +1,4 @@
-document.addEventListener('turbolinks:load', () => {
+document.addEventListener('turbo:load', () => {
     window.app.$on('checkout-payment-saved', (data) => {
         if (!data.order.payment_method_code.includes('paynl_')) {
             return;


### PR DESCRIPTION
Required for the migration from Turbolinks to Turbo in Core.