### PR TITLE
Add orderId existence check before executing GraphQL query

### DIFF
--- a/src/Http/Controllers/FinishTransactionController.php
+++ b/src/Http/Controllers/FinishTransactionController.php
@@ -2,31 +2,38 @@
 
 namespace Rapidez\Paynl\Http\Controllers;
 
+use Illuminate\Http\Client\RequestException;
 use Illuminate\Routing\Controller;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Http\Request;
 
 class FinishTransactionController extends Controller
 {
+    /**
+     * @throws RequestException
+     */
     public function __invoke(Request $request)
     {
+        $orderId = $request->get('orderId');
+        if (empty($orderId)) {
+            return redirect('cart');
+        }
+
         $url = config('rapidez.magento_url').'/graphql';
-    
         $response = Http::withHeaders(['Store' => config('rapidez.store_code')])
             ->post($url, [
                 'query' => view('paynl::graphql.finish-transaction')->render(),
                 'variables' => [
-                    'pay_order_id' => $request->get('orderId')
+                    'pay_order_id' => $orderId
                 ]
             ])
             ->throw()
             ->object();
-    
+
         if (!optional($response->data->paynlFinishTransaction)->isSuccess ?? false) {
             return redirect('cart');
         }
-    
+
         return view('paynl::success');
     }
 }
-


### PR DESCRIPTION
This adds a check to ensure that the orderId exists before executing the GraphQL query. Occasionally, users try to navigate back from the success step, resulting in the orderId being missing. This check helps prevent errors by redirecting the user to the cart page if the orderId is empty. This ensures that the GraphQL query is executed only when an orderId is present.